### PR TITLE
Fix bug where existing points are not removed when calling load() on SuperclusterMutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,21 @@
+## 2.1.1
+
+- BUGFIX: SuperclusterMutable now removes existing points when calling load(). This was the
+  documented behaviour but there was a bug in the implementation. Thanks
+  [`@Robbendebiene`](https://github.com/Robbendebiene) for pointing this out.
+
 ## 2.1.0
 
-- Add new `contains` function which returns true if the provided point is
-  contained in the index.
+- Add new `contains` function which returns true if the provided point is contained in the index.
 
 ## 2.0.0
 
-- BREAKING: SuperclusterImmutable no longer has a `points` argument. Instead the
-            points should be set by calling load() as is done with
-            SuperclusterMutable.
-- BREAKING: onClusterDataChange callback has been removed. If you want to
-            react to cluster data changes you can do so after:
-              - `load` is called.
-              - `remove` is called and returns true.
-              - `modifyPointData` is called and returns true.
+- BREAKING: SuperclusterImmutable no longer has a `points` argument. Instead the points should be
+  set by calling load() as is done with SuperclusterMutable.
+- BREAKING: onClusterDataChange callback has been removed. If you want to react to cluster data
+  changes you can do so after:
+  - `load` is called. - `remove` is called and returns true. - `modifyPointData` is called and
+    returns true.
 
 ## 1.0.0
 

--- a/lib/src/mutable/mutable_layer.dart
+++ b/lib/src/mutable/mutable_layer.dart
@@ -19,6 +19,10 @@ class MutableLayer<T> {
     required this.searchRadius,
   }) : _innerTree = RBush(nodeSize);
 
+  void clear() {
+    _innerTree.clear();
+  }
+
   void load(List<RBushElement<MutableLayerElement<T>>> elements) {
     _innerTree.load(elements);
   }

--- a/lib/src/mutable/supercluster_mutable.dart
+++ b/lib/src/mutable/supercluster_mutable.dart
@@ -59,7 +59,9 @@ class SuperclusterMutable<T> extends Supercluster<T> {
         .map((point) => _initializePoint(point).positionRBushPoint())
         .toList();
 
-    _trees[maxZoom + 1].load(clusters);
+    _trees[maxZoom + 1]
+      ..clear()
+      ..load(clusters);
 
     // cluster points on max zoom, then cluster the results on previous zoom, etc.;
     // results in a cluster hierarchy across zoom levels
@@ -68,7 +70,9 @@ class SuperclusterMutable<T> extends Supercluster<T> {
           .cluster(clusters, z, _trees[z + 1])
           .map((c) => c.positionRBushPoint())
           .toList(); // create a new set of clusters for the zoom
-      _trees[z].load(clusters); // index input points into an R-tree
+      _trees[z]
+        ..clear()
+        ..load(clusters); // index input points into an R-tree
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supercluster
 description: A port of MapBox's javascript supercluster library for fast clustering, with added mutable clustering support.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/rorystephenson/supercluster_dart
 
 environment:

--- a/test/supercluster_immutable_test.dart
+++ b/test/supercluster_immutable_test.dart
@@ -21,6 +21,13 @@ void main() {
         maxZoom: maxZoom,
       )..load(points);
 
+  test('removes existing points when calling load()', () {
+    final index = supercluster(Fixtures.features);
+    index.load([]);
+    expect(index.points, isEmpty);
+    expect(index.getLeaves(), isEmpty);
+  });
+
   test('returns children of a cluster', () {
     final index = supercluster(Fixtures.features);
     final childCounts = index.childrenOf(163).map((p) => p.numPoints);

--- a/test/supercluster_mutable_test.dart
+++ b/test/supercluster_mutable_test.dart
@@ -111,6 +111,12 @@ void main() {
     ]);
   });
 
+  test('removes existing points when calling load()', () {
+    final index = supercluster(Fixtures.features);
+    index.load([]);
+    expect(numPointsAtZoom(index, index.maxZoom), 0);
+  });
+
   test('clusters points with a minimum cluster size', () {
     final index = supercluster(Fixtures.features, minPoints: 5);
     expect(pointCountsAtZooms(index), [


### PR DESCRIPTION
SuperclusterMutable now removes existing points when calling load(). This was the documented behaviour but there was a bug in the implementation.

Fixes #3 .