### PR TITLE
Bump uuid dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   freezed_annotation: ^2.4.1
   kdbush: ^0.1.0
   rbush: ^1.1.0
-  uuid: ^3.0.7
+  uuid: ^4.4.0
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
Update uuid package to resolve a dependency conflict with geolocator. (see https://pub.dev/packages/geolocator_android/changelog#432)