### PR TITLE
v3.2.0

### DIFF
--- a/example/supercluster_immutable_example.dart
+++ b/example/supercluster_immutable_example.dart
@@ -14,10 +14,12 @@ void main() {
   )..load(points);
 
   final clustersAndPoints = supercluster.search(0, 40, 20, 50, 5).map(
-        (e) => e.map(
-          cluster: (cluster) => 'cluster (${cluster.numPoints} points)',
-          point: (point) => 'point ${point.originalPoint}',
-        ),
+        (e) => switch (e) {
+          ImmutableLayerCluster<MapPoint> cluster =>
+            'cluster (${cluster.numPoints} points)',
+          ImmutableLayerPoint<MapPoint> point => 'point ${point.originalPoint}',
+          ImmutableLayerElement<MapPoint>() => throw UnimplementedError(),
+        },
       );
 
   print(clustersAndPoints.join(', '));

--- a/example/supercluster_mutable_example.dart
+++ b/example/supercluster_mutable_example.dart
@@ -17,12 +17,13 @@ void main() {
   )..load(points);
 
   var clustersAndPoints = supercluster.search(0.0, 40, 20, 50, 5).map(
-        (e) => e.map(
-          cluster: (cluster) => 'cluster (${cluster.numPoints} points)',
-          point: (point) => 'point ${point.originalPoint}',
-        ),
+        (e) => switch (e) {
+          MutableLayerCluster<MapPoint> cluster =>
+            'cluster (${cluster.numPoints} points)',
+          MutableLayerPoint<MapPoint> point => 'point ${point.originalPoint}',
+          MutableLayerElement<MapPoint>() => throw UnimplementedError(),
+        },
       );
-
   print(clustersAndPoints.join(', '));
   // prints: cluster (2 points), point "third" (45.0, 19.0)
 
@@ -30,9 +31,12 @@ void main() {
   supercluster.remove(points[1]);
 
   clustersAndPoints = supercluster.search(0.0, 40, 20, 50, 5).map(
-        (e) => e.map(
-            cluster: (cluster) => 'cluster (${cluster.numPoints} points)',
-            point: (point) => 'point ${point.originalPoint}'),
+        (e) => switch (e) {
+          MutableLayerCluster<MapPoint> cluster =>
+            'cluster (${cluster.numPoints} points)',
+          MutableLayerPoint<MapPoint> point => 'point ${point.originalPoint}',
+          MutableLayerElement<MapPoint>() => throw UnimplementedError(),
+        },
       );
 
   print(clustersAndPoints.join(', '));

--- a/lib/src/immutable/immutable_layer_element.freezed.dart
+++ b/lib/src/immutable/immutable_layer_element.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,214 +10,47 @@ part of 'immutable_layer_element.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$ImmutableLayerElement<T> {
-  double get x => throw _privateConstructorUsedError;
-  double get y => throw _privateConstructorUsedError;
-  ClusterDataBase? get clusterData => throw _privateConstructorUsedError;
-  set clusterData(ClusterDataBase? value) => throw _privateConstructorUsedError;
-  int get visitedAtZoom => throw _privateConstructorUsedError;
-  set visitedAtZoom(int value) => throw _privateConstructorUsedError;
-  int get lowestZoom => throw _privateConstructorUsedError;
-  set lowestZoom(int value) => throw _privateConstructorUsedError;
-  int get highestZoom => throw _privateConstructorUsedError;
-  set highestZoom(int value) => throw _privateConstructorUsedError;
-  int get parentId => throw _privateConstructorUsedError;
-  set parentId(int value) => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)
-        cluster,
-    required TResult Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)
-        point,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)?
-        cluster,
-    TResult? Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)?
-        point,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)?
-        cluster,
-    TResult Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)?
-        point,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(ImmutableLayerCluster<T> value) cluster,
-    required TResult Function(ImmutableLayerPoint<T> value) point,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(ImmutableLayerCluster<T> value)? cluster,
-    TResult? Function(ImmutableLayerPoint<T> value)? point,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(ImmutableLayerCluster<T> value)? cluster,
-    TResult Function(ImmutableLayerPoint<T> value)? point,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
+  double get x;
+  double get y;
+  ClusterDataBase? get clusterData;
+  set clusterData(ClusterDataBase? value);
+  int get visitedAtZoom;
+  set visitedAtZoom(int value);
+  int get lowestZoom;
+  set lowestZoom(int value);
+  int get highestZoom;
+  set highestZoom(int value);
+  int get parentId;
+  set parentId(int value);
 
-  @JsonKey(ignore: true)
-  $ImmutableLayerElementCopyWith<T, ImmutableLayerElement<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ImmutableLayerElementCopyWith<T, $Res> {
-  factory $ImmutableLayerElementCopyWith(ImmutableLayerElement<T> value,
-          $Res Function(ImmutableLayerElement<T>) then) =
-      _$ImmutableLayerElementCopyWithImpl<T, $Res, ImmutableLayerElement<T>>;
-  @useResult
-  $Res call(
-      {double x,
-      double y,
-      ClusterDataBase? clusterData,
-      int visitedAtZoom,
-      int lowestZoom,
-      int highestZoom,
-      int parentId});
-}
-
-/// @nodoc
-class _$ImmutableLayerElementCopyWithImpl<T, $Res,
-        $Val extends ImmutableLayerElement<T>>
-    implements $ImmutableLayerElementCopyWith<T, $Res> {
-  _$ImmutableLayerElementCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
+  /// Create a copy of ImmutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
+  $ImmutableLayerElementCopyWith<T, ImmutableLayerElement<T>> get copyWith =>
+      _$ImmutableLayerElementCopyWithImpl<T, ImmutableLayerElement<T>>(
+          this as ImmutableLayerElement<T>, _$identity);
+
   @override
-  $Res call({
-    Object? x = null,
-    Object? y = null,
-    Object? clusterData = freezed,
-    Object? visitedAtZoom = null,
-    Object? lowestZoom = null,
-    Object? highestZoom = null,
-    Object? parentId = null,
-  }) {
-    return _then(_value.copyWith(
-      x: null == x
-          ? _value.x
-          : x // ignore: cast_nullable_to_non_nullable
-              as double,
-      y: null == y
-          ? _value.y
-          : y // ignore: cast_nullable_to_non_nullable
-              as double,
-      clusterData: freezed == clusterData
-          ? _value.clusterData
-          : clusterData // ignore: cast_nullable_to_non_nullable
-              as ClusterDataBase?,
-      visitedAtZoom: null == visitedAtZoom
-          ? _value.visitedAtZoom
-          : visitedAtZoom // ignore: cast_nullable_to_non_nullable
-              as int,
-      lowestZoom: null == lowestZoom
-          ? _value.lowestZoom
-          : lowestZoom // ignore: cast_nullable_to_non_nullable
-              as int,
-      highestZoom: null == highestZoom
-          ? _value.highestZoom
-          : highestZoom // ignore: cast_nullable_to_non_nullable
-              as int,
-      parentId: null == parentId
-          ? _value.parentId
-          : parentId // ignore: cast_nullable_to_non_nullable
-              as int,
-    ) as $Val);
+  String toString() {
+    return 'ImmutableLayerElement<$T>(x: $x, y: $y, clusterData: $clusterData, visitedAtZoom: $visitedAtZoom, lowestZoom: $lowestZoom, highestZoom: $highestZoom, parentId: $parentId)';
   }
 }
 
 /// @nodoc
-abstract class _$$ImmutableLayerClusterImplCopyWith<T, $Res>
-    implements $ImmutableLayerElementCopyWith<T, $Res> {
-  factory _$$ImmutableLayerClusterImplCopyWith(
-          _$ImmutableLayerClusterImpl<T> value,
-          $Res Function(_$ImmutableLayerClusterImpl<T>) then) =
-      __$$ImmutableLayerClusterImplCopyWithImpl<T, $Res>;
-  @override
+abstract mixin class $ImmutableLayerElementCopyWith<T, $Res> {
+  factory $ImmutableLayerElementCopyWith(ImmutableLayerElement<T> value,
+          $Res Function(ImmutableLayerElement<T>) _then) =
+      _$ImmutableLayerElementCopyWithImpl;
   @useResult
   $Res call(
       {double x,
       double y,
-      int childPointCount,
-      int id,
       ClusterDataBase? clusterData,
       int visitedAtZoom,
       int lowestZoom,
@@ -225,63 +59,53 @@ abstract class _$$ImmutableLayerClusterImplCopyWith<T, $Res>
 }
 
 /// @nodoc
-class __$$ImmutableLayerClusterImplCopyWithImpl<T, $Res>
-    extends _$ImmutableLayerElementCopyWithImpl<T, $Res,
-        _$ImmutableLayerClusterImpl<T>>
-    implements _$$ImmutableLayerClusterImplCopyWith<T, $Res> {
-  __$$ImmutableLayerClusterImplCopyWithImpl(
-      _$ImmutableLayerClusterImpl<T> _value,
-      $Res Function(_$ImmutableLayerClusterImpl<T>) _then)
-      : super(_value, _then);
+class _$ImmutableLayerElementCopyWithImpl<T, $Res>
+    implements $ImmutableLayerElementCopyWith<T, $Res> {
+  _$ImmutableLayerElementCopyWithImpl(this._self, this._then);
 
+  final ImmutableLayerElement<T> _self;
+  final $Res Function(ImmutableLayerElement<T>) _then;
+
+  /// Create a copy of ImmutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? x = null,
     Object? y = null,
-    Object? childPointCount = null,
-    Object? id = null,
     Object? clusterData = freezed,
     Object? visitedAtZoom = null,
     Object? lowestZoom = null,
     Object? highestZoom = null,
     Object? parentId = null,
   }) {
-    return _then(_$ImmutableLayerClusterImpl<T>(
+    return _then(_self.copyWith(
       x: null == x
-          ? _value.x
+          ? _self.x
           : x // ignore: cast_nullable_to_non_nullable
               as double,
       y: null == y
-          ? _value.y
+          ? _self.y
           : y // ignore: cast_nullable_to_non_nullable
               as double,
-      childPointCount: null == childPointCount
-          ? _value.childPointCount
-          : childPointCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as int,
       clusterData: freezed == clusterData
-          ? _value.clusterData
+          ? _self.clusterData
           : clusterData // ignore: cast_nullable_to_non_nullable
               as ClusterDataBase?,
       visitedAtZoom: null == visitedAtZoom
-          ? _value.visitedAtZoom
+          ? _self.visitedAtZoom
           : visitedAtZoom // ignore: cast_nullable_to_non_nullable
               as int,
       lowestZoom: null == lowestZoom
-          ? _value.lowestZoom
+          ? _self.lowestZoom
           : lowestZoom // ignore: cast_nullable_to_non_nullable
               as int,
       highestZoom: null == highestZoom
-          ? _value.highestZoom
+          ? _self.highestZoom
           : highestZoom // ignore: cast_nullable_to_non_nullable
               as int,
       parentId: null == parentId
-          ? _value.parentId
+          ? _self.parentId
           : parentId // ignore: cast_nullable_to_non_nullable
               as int,
     ));
@@ -290,9 +114,9 @@ class __$$ImmutableLayerClusterImplCopyWithImpl<T, $Res>
 
 /// @nodoc
 
-class _$ImmutableLayerClusterImpl<T> extends ImmutableLayerCluster<T>
+class ImmutableLayerCluster<T> extends ImmutableLayerElement<T>
     with LayerCluster<T> {
-  _$ImmutableLayerClusterImpl(
+  ImmutableLayerCluster(
       {required this.x,
       required this.y,
       required this.childPointCount,
@@ -308,9 +132,7 @@ class _$ImmutableLayerClusterImpl<T> extends ImmutableLayerCluster<T>
   final double x;
   @override
   final double y;
-  @override
   final int childPointCount;
-  @override
   final int id;
   @override
   ClusterDataBase? clusterData;
@@ -324,191 +146,160 @@ class _$ImmutableLayerClusterImpl<T> extends ImmutableLayerCluster<T>
   @JsonKey()
   int parentId;
 
+  /// Create a copy of ImmutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ImmutableLayerClusterCopyWith<T, ImmutableLayerCluster<T>> get copyWith =>
+      _$ImmutableLayerClusterCopyWithImpl<T, ImmutableLayerCluster<T>>(
+          this, _$identity);
+
   @override
   String toString() {
     return 'ImmutableLayerElement<$T>.cluster(x: $x, y: $y, childPointCount: $childPointCount, id: $id, clusterData: $clusterData, visitedAtZoom: $visitedAtZoom, lowestZoom: $lowestZoom, highestZoom: $highestZoom, parentId: $parentId)';
   }
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ImmutableLayerClusterImplCopyWith<T, _$ImmutableLayerClusterImpl<T>>
-      get copyWith => __$$ImmutableLayerClusterImplCopyWithImpl<T,
-          _$ImmutableLayerClusterImpl<T>>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)
-        cluster,
-    required TResult Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)
-        point,
-  }) {
-    return cluster(x, y, childPointCount, id, clusterData, visitedAtZoom,
-        lowestZoom, highestZoom, parentId);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)?
-        cluster,
-    TResult? Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)?
-        point,
-  }) {
-    return cluster?.call(x, y, childPointCount, id, clusterData, visitedAtZoom,
-        lowestZoom, highestZoom, parentId);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)?
-        cluster,
-    TResult Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)?
-        point,
-    required TResult orElse(),
-  }) {
-    if (cluster != null) {
-      return cluster(x, y, childPointCount, id, clusterData, visitedAtZoom,
-          lowestZoom, highestZoom, parentId);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(ImmutableLayerCluster<T> value) cluster,
-    required TResult Function(ImmutableLayerPoint<T> value) point,
-  }) {
-    return cluster(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(ImmutableLayerCluster<T> value)? cluster,
-    TResult? Function(ImmutableLayerPoint<T> value)? point,
-  }) {
-    return cluster?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(ImmutableLayerCluster<T> value)? cluster,
-    TResult Function(ImmutableLayerPoint<T> value)? point,
-    required TResult orElse(),
-  }) {
-    if (cluster != null) {
-      return cluster(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class ImmutableLayerCluster<T> extends ImmutableLayerElement<T>
-    implements LayerCluster<T> {
-  factory ImmutableLayerCluster(
-      {required final double x,
-      required final double y,
-      required final int childPointCount,
-      required final int id,
-      ClusterDataBase? clusterData,
-      required int visitedAtZoom,
-      required int lowestZoom,
-      required int highestZoom,
-      int parentId}) = _$ImmutableLayerClusterImpl<T>;
-  ImmutableLayerCluster._() : super._();
-
-  @override
-  double get x;
-  @override
-  double get y;
-  int get childPointCount;
-  int get id;
-  @override
-  ClusterDataBase? get clusterData;
-  set clusterData(ClusterDataBase? value);
-  @override
-  int get visitedAtZoom;
-  set visitedAtZoom(int value);
-  @override
-  int get lowestZoom;
-  set lowestZoom(int value);
-  @override
-  int get highestZoom;
-  set highestZoom(int value);
-  @override
-  int get parentId;
-  set parentId(int value);
-  @override
-  @JsonKey(ignore: true)
-  _$$ImmutableLayerClusterImplCopyWith<T, _$ImmutableLayerClusterImpl<T>>
-      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$ImmutableLayerPointImplCopyWith<T, $Res>
+abstract mixin class $ImmutableLayerClusterCopyWith<T, $Res>
     implements $ImmutableLayerElementCopyWith<T, $Res> {
-  factory _$$ImmutableLayerPointImplCopyWith(_$ImmutableLayerPointImpl<T> value,
-          $Res Function(_$ImmutableLayerPointImpl<T>) then) =
-      __$$ImmutableLayerPointImplCopyWithImpl<T, $Res>;
+  factory $ImmutableLayerClusterCopyWith(ImmutableLayerCluster<T> value,
+          $Res Function(ImmutableLayerCluster<T>) _then) =
+      _$ImmutableLayerClusterCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {double x,
+      double y,
+      int childPointCount,
+      int id,
+      ClusterDataBase? clusterData,
+      int visitedAtZoom,
+      int lowestZoom,
+      int highestZoom,
+      int parentId});
+}
+
+/// @nodoc
+class _$ImmutableLayerClusterCopyWithImpl<T, $Res>
+    implements $ImmutableLayerClusterCopyWith<T, $Res> {
+  _$ImmutableLayerClusterCopyWithImpl(this._self, this._then);
+
+  final ImmutableLayerCluster<T> _self;
+  final $Res Function(ImmutableLayerCluster<T>) _then;
+
+  /// Create a copy of ImmutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? x = null,
+    Object? y = null,
+    Object? childPointCount = null,
+    Object? id = null,
+    Object? clusterData = freezed,
+    Object? visitedAtZoom = null,
+    Object? lowestZoom = null,
+    Object? highestZoom = null,
+    Object? parentId = null,
+  }) {
+    return _then(ImmutableLayerCluster<T>(
+      x: null == x
+          ? _self.x
+          : x // ignore: cast_nullable_to_non_nullable
+              as double,
+      y: null == y
+          ? _self.y
+          : y // ignore: cast_nullable_to_non_nullable
+              as double,
+      childPointCount: null == childPointCount
+          ? _self.childPointCount
+          : childPointCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      clusterData: freezed == clusterData
+          ? _self.clusterData
+          : clusterData // ignore: cast_nullable_to_non_nullable
+              as ClusterDataBase?,
+      visitedAtZoom: null == visitedAtZoom
+          ? _self.visitedAtZoom
+          : visitedAtZoom // ignore: cast_nullable_to_non_nullable
+              as int,
+      lowestZoom: null == lowestZoom
+          ? _self.lowestZoom
+          : lowestZoom // ignore: cast_nullable_to_non_nullable
+              as int,
+      highestZoom: null == highestZoom
+          ? _self.highestZoom
+          : highestZoom // ignore: cast_nullable_to_non_nullable
+              as int,
+      parentId: null == parentId
+          ? _self.parentId
+          : parentId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class ImmutableLayerPoint<T> extends ImmutableLayerElement<T>
+    with LayerPoint<T> {
+  ImmutableLayerPoint(
+      {required this.originalPoint,
+      required this.x,
+      required this.y,
+      required this.index,
+      this.clusterData,
+      this.parentId = -1,
+      required this.visitedAtZoom,
+      required this.lowestZoom,
+      required this.highestZoom})
+      : super._();
+
+  T originalPoint;
+  @override
+  final double x;
+  @override
+  final double y;
+  final int index;
+  @override
+  ClusterDataBase? clusterData;
+  @override
+  @JsonKey()
+  int parentId;
+  @override
+  int visitedAtZoom;
+  @override
+  int lowestZoom;
+  @override
+  int highestZoom;
+
+  /// Create a copy of ImmutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ImmutableLayerPointCopyWith<T, ImmutableLayerPoint<T>> get copyWith =>
+      _$ImmutableLayerPointCopyWithImpl<T, ImmutableLayerPoint<T>>(
+          this, _$identity);
+
+  @override
+  String toString() {
+    return 'ImmutableLayerElement<$T>.point(originalPoint: $originalPoint, x: $x, y: $y, index: $index, clusterData: $clusterData, parentId: $parentId, visitedAtZoom: $visitedAtZoom, lowestZoom: $lowestZoom, highestZoom: $highestZoom)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ImmutableLayerPointCopyWith<T, $Res>
+    implements $ImmutableLayerElementCopyWith<T, $Res> {
+  factory $ImmutableLayerPointCopyWith(ImmutableLayerPoint<T> value,
+          $Res Function(ImmutableLayerPoint<T>) _then) =
+      _$ImmutableLayerPointCopyWithImpl;
   @override
   @useResult
   $Res call(
@@ -524,16 +315,17 @@ abstract class _$$ImmutableLayerPointImplCopyWith<T, $Res>
 }
 
 /// @nodoc
-class __$$ImmutableLayerPointImplCopyWithImpl<T, $Res>
-    extends _$ImmutableLayerElementCopyWithImpl<T, $Res,
-        _$ImmutableLayerPointImpl<T>>
-    implements _$$ImmutableLayerPointImplCopyWith<T, $Res> {
-  __$$ImmutableLayerPointImplCopyWithImpl(_$ImmutableLayerPointImpl<T> _value,
-      $Res Function(_$ImmutableLayerPointImpl<T>) _then)
-      : super(_value, _then);
+class _$ImmutableLayerPointCopyWithImpl<T, $Res>
+    implements $ImmutableLayerPointCopyWith<T, $Res> {
+  _$ImmutableLayerPointCopyWithImpl(this._self, this._then);
 
-  @pragma('vm:prefer-inline')
+  final ImmutableLayerPoint<T> _self;
+  final $Res Function(ImmutableLayerPoint<T>) _then;
+
+  /// Create a copy of ImmutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
   @override
+  @pragma('vm:prefer-inline')
   $Res call({
     Object? originalPoint = freezed,
     Object? x = null,
@@ -545,259 +337,45 @@ class __$$ImmutableLayerPointImplCopyWithImpl<T, $Res>
     Object? lowestZoom = null,
     Object? highestZoom = null,
   }) {
-    return _then(_$ImmutableLayerPointImpl<T>(
+    return _then(ImmutableLayerPoint<T>(
       originalPoint: freezed == originalPoint
-          ? _value.originalPoint
+          ? _self.originalPoint
           : originalPoint // ignore: cast_nullable_to_non_nullable
               as T,
       x: null == x
-          ? _value.x
+          ? _self.x
           : x // ignore: cast_nullable_to_non_nullable
               as double,
       y: null == y
-          ? _value.y
+          ? _self.y
           : y // ignore: cast_nullable_to_non_nullable
               as double,
       index: null == index
-          ? _value.index
+          ? _self.index
           : index // ignore: cast_nullable_to_non_nullable
               as int,
       clusterData: freezed == clusterData
-          ? _value.clusterData
+          ? _self.clusterData
           : clusterData // ignore: cast_nullable_to_non_nullable
               as ClusterDataBase?,
       parentId: null == parentId
-          ? _value.parentId
+          ? _self.parentId
           : parentId // ignore: cast_nullable_to_non_nullable
               as int,
       visitedAtZoom: null == visitedAtZoom
-          ? _value.visitedAtZoom
+          ? _self.visitedAtZoom
           : visitedAtZoom // ignore: cast_nullable_to_non_nullable
               as int,
       lowestZoom: null == lowestZoom
-          ? _value.lowestZoom
+          ? _self.lowestZoom
           : lowestZoom // ignore: cast_nullable_to_non_nullable
               as int,
       highestZoom: null == highestZoom
-          ? _value.highestZoom
+          ? _self.highestZoom
           : highestZoom // ignore: cast_nullable_to_non_nullable
               as int,
     ));
   }
 }
 
-/// @nodoc
-
-class _$ImmutableLayerPointImpl<T> extends ImmutableLayerPoint<T>
-    with LayerPoint<T> {
-  _$ImmutableLayerPointImpl(
-      {required this.originalPoint,
-      required this.x,
-      required this.y,
-      required this.index,
-      this.clusterData,
-      this.parentId = -1,
-      required this.visitedAtZoom,
-      required this.lowestZoom,
-      required this.highestZoom})
-      : super._();
-
-  @override
-  T originalPoint;
-  @override
-  final double x;
-  @override
-  final double y;
-  @override
-  final int index;
-  @override
-  ClusterDataBase? clusterData;
-  @override
-  @JsonKey()
-  int parentId;
-  @override
-  int visitedAtZoom;
-  @override
-  int lowestZoom;
-  @override
-  int highestZoom;
-
-  @override
-  String toString() {
-    return 'ImmutableLayerElement<$T>.point(originalPoint: $originalPoint, x: $x, y: $y, index: $index, clusterData: $clusterData, parentId: $parentId, visitedAtZoom: $visitedAtZoom, lowestZoom: $lowestZoom, highestZoom: $highestZoom)';
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$ImmutableLayerPointImplCopyWith<T, _$ImmutableLayerPointImpl<T>>
-      get copyWith => __$$ImmutableLayerPointImplCopyWithImpl<T,
-          _$ImmutableLayerPointImpl<T>>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)
-        cluster,
-    required TResult Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)
-        point,
-  }) {
-    return point(originalPoint, x, y, index, clusterData, parentId,
-        visitedAtZoom, lowestZoom, highestZoom);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)?
-        cluster,
-    TResult? Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)?
-        point,
-  }) {
-    return point?.call(originalPoint, x, y, index, clusterData, parentId,
-        visitedAtZoom, lowestZoom, highestZoom);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            double x,
-            double y,
-            int childPointCount,
-            int id,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            int parentId)?
-        cluster,
-    TResult Function(
-            T originalPoint,
-            double x,
-            double y,
-            int index,
-            ClusterDataBase? clusterData,
-            int parentId,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom)?
-        point,
-    required TResult orElse(),
-  }) {
-    if (point != null) {
-      return point(originalPoint, x, y, index, clusterData, parentId,
-          visitedAtZoom, lowestZoom, highestZoom);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(ImmutableLayerCluster<T> value) cluster,
-    required TResult Function(ImmutableLayerPoint<T> value) point,
-  }) {
-    return point(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(ImmutableLayerCluster<T> value)? cluster,
-    TResult? Function(ImmutableLayerPoint<T> value)? point,
-  }) {
-    return point?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(ImmutableLayerCluster<T> value)? cluster,
-    TResult Function(ImmutableLayerPoint<T> value)? point,
-    required TResult orElse(),
-  }) {
-    if (point != null) {
-      return point(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class ImmutableLayerPoint<T> extends ImmutableLayerElement<T>
-    implements LayerPoint<T> {
-  factory ImmutableLayerPoint(
-      {required T originalPoint,
-      required final double x,
-      required final double y,
-      required final int index,
-      ClusterDataBase? clusterData,
-      int parentId,
-      required int visitedAtZoom,
-      required int lowestZoom,
-      required int highestZoom}) = _$ImmutableLayerPointImpl<T>;
-  ImmutableLayerPoint._() : super._();
-
-  T get originalPoint;
-  set originalPoint(T value);
-  @override
-  double get x;
-  @override
-  double get y;
-  int get index;
-  @override
-  ClusterDataBase? get clusterData;
-  set clusterData(ClusterDataBase? value);
-  @override
-  int get parentId;
-  set parentId(int value);
-  @override
-  int get visitedAtZoom;
-  set visitedAtZoom(int value);
-  @override
-  int get lowestZoom;
-  set lowestZoom(int value);
-  @override
-  int get highestZoom;
-  set highestZoom(int value);
-  @override
-  @JsonKey(ignore: true)
-  _$$ImmutableLayerPointImplCopyWith<T, _$ImmutableLayerPointImpl<T>>
-      get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/immutable/supercluster_immutable.dart
+++ b/lib/src/immutable/supercluster_immutable.dart
@@ -267,11 +267,13 @@ class SuperclusterImmutable<T> extends Supercluster<T> {
   }
 
   ClusterDataBase _extractClusterData(
-      ImmutableLayerElement<T> clusterOrMapPoint) {
-    return clusterOrMapPoint.map(
-        cluster: (cluster) => cluster.clusterData!,
-        point: (mapPoint) => extractClusterData!(mapPoint.originalPoint));
-  }
+          ImmutableLayerElement<T> clusterOrMapPoint) =>
+      switch (clusterOrMapPoint) {
+        ImmutableLayerCluster<T> cluster => cluster.clusterData!,
+        ImmutableLayerPoint<T> mapPoint =>
+          extractClusterData!(mapPoint.originalPoint),
+        ImmutableLayerElement<T>() => throw UnimplementedError(),
+      };
 
   // get index of the point from which the cluster originated
   int _getOriginId(int clusterId) {

--- a/lib/src/mutable/layer_clusterer.dart
+++ b/lib/src/mutable/layer_clusterer.dart
@@ -115,11 +115,13 @@ class LayerClusterer<T> {
     return clusters;
   }
 
-  ClusterDataBase _extractClusterData(MutableLayerElement<T> clusterOrPoint) {
-    return clusterOrPoint.map(
-        cluster: (cluster) => cluster.clusterData!,
-        point: (mapPoint) => extractClusterData!(mapPoint.originalPoint));
-  }
+  ClusterDataBase _extractClusterData(MutableLayerElement<T> clusterOrPoint) =>
+      switch (clusterOrPoint) {
+        MutableLayerCluster<T> cluster => cluster.clusterData!,
+        MutableLayerPoint<T> mapPoint =>
+          extractClusterData!(mapPoint.originalPoint),
+        MutableLayerElement<T>() => throw UnimplementedError(),
+      };
 
   bool _closeEnoughToCluster(
     MutableLayerElement<T> a,

--- a/lib/src/mutable/mutable_layer_element.dart
+++ b/lib/src/mutable/mutable_layer_element.dart
@@ -8,7 +8,8 @@ import 'rbush_point.dart';
 part 'mutable_layer_element.freezed.dart';
 
 @unfreezed
-class MutableLayerElement<T> with _$MutableLayerElement<T>, LayerElement<T> {
+abstract class MutableLayerElement<T>
+    with _$MutableLayerElement<T>, LayerElement<T> {
   MutableLayerElement._();
 
   @With.fromString("LayerCluster<T>")
@@ -89,8 +90,11 @@ class MutableLayerElement<T> with _$MutableLayerElement<T>, LayerElement<T> {
     );
   }
 
-  int get numPoints =>
-      map(cluster: (cluster) => cluster.childPointCount, point: (point) => 1);
+  int get numPoints => switch (this) {
+        MutableLayerCluster(childPointCount: var count) => count,
+        MutableLayerPoint() => 1,
+        MutableLayerElement<T>() => throw UnimplementedError(),
+      };
 
   static double getX(MutableLayerElement clusterOrMapPoint) =>
       clusterOrMapPoint.x;
@@ -107,8 +111,15 @@ class MutableLayerElement<T> with _$MutableLayerElement<T>, LayerElement<T> {
     required TResult Function(LayerCluster<T> cluster) cluster,
     required TResult Function(LayerPoint<T> point) point,
   }) =>
-      map(cluster: cluster, point: point);
+      switch (this) {
+        MutableLayerCluster<T> clusterInstance => cluster(clusterInstance),
+        MutableLayerPoint<T> pointInstance => point(pointInstance),
+        _ => throw UnimplementedError(),
+      };
 
-  String get summary =>
-      '${map(cluster: (cluster) => 'cluster', point: (point) => 'point')}($uuid < $parentUuid, $highestZoom - $lowestZoom)';
+  String get summary => '${switch (this) {
+        MutableLayerCluster<T> _ => 'cluster',
+        MutableLayerPoint<T> _ => 'point',
+        _ => throw UnimplementedError(),
+      }}($uuid < $parentUuid, $highestZoom - $lowestZoom)';
 }

--- a/lib/src/mutable/mutable_layer_element.freezed.dart
+++ b/lib/src/mutable/mutable_layer_element.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,234 +10,52 @@ part of 'mutable_layer_element.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$MutableLayerElement<T> {
-  String get uuid => throw _privateConstructorUsedError;
-  set uuid(String value) => throw _privateConstructorUsedError;
-  double get x => throw _privateConstructorUsedError;
-  set x(double value) => throw _privateConstructorUsedError;
-  double get y => throw _privateConstructorUsedError;
-  set y(double value) => throw _privateConstructorUsedError;
-  ClusterDataBase? get clusterData => throw _privateConstructorUsedError;
-  set clusterData(ClusterDataBase? value) => throw _privateConstructorUsedError;
-  int get visitedAtZoom => throw _privateConstructorUsedError;
-  set visitedAtZoom(int value) => throw _privateConstructorUsedError;
-  int get lowestZoom => throw _privateConstructorUsedError;
-  set lowestZoom(int value) => throw _privateConstructorUsedError;
-  int get highestZoom => throw _privateConstructorUsedError;
-  set highestZoom(int value) => throw _privateConstructorUsedError;
-  String? get parentUuid => throw _privateConstructorUsedError;
-  set parentUuid(String? value) => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)
-        cluster,
-    required TResult Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)
-        point,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        cluster,
-    TResult? Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        point,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        cluster,
-    TResult Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        point,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(MutableLayerCluster<T> value) cluster,
-    required TResult Function(MutableLayerPoint<T> value) point,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(MutableLayerCluster<T> value)? cluster,
-    TResult? Function(MutableLayerPoint<T> value)? point,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(MutableLayerCluster<T> value)? cluster,
-    TResult Function(MutableLayerPoint<T> value)? point,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
+  String get uuid;
+  set uuid(String value); // Zero-based index of point addition.
+  double get x; // Zero-based index of point addition.
+  set x(double value);
+  double get y;
+  set y(double value);
+  ClusterDataBase? get clusterData;
+  set clusterData(ClusterDataBase? value);
+  int get visitedAtZoom;
+  set visitedAtZoom(int value);
+  int get lowestZoom;
+  set lowestZoom(int value);
+  int get highestZoom;
+  set highestZoom(int value);
+  String? get parentUuid;
+  set parentUuid(String? value);
 
-  @JsonKey(ignore: true)
-  $MutableLayerElementCopyWith<T, MutableLayerElement<T>> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $MutableLayerElementCopyWith<T, $Res> {
-  factory $MutableLayerElementCopyWith(MutableLayerElement<T> value,
-          $Res Function(MutableLayerElement<T>) then) =
-      _$MutableLayerElementCopyWithImpl<T, $Res, MutableLayerElement<T>>;
-  @useResult
-  $Res call(
-      {String uuid,
-      double x,
-      double y,
-      ClusterDataBase? clusterData,
-      int visitedAtZoom,
-      int lowestZoom,
-      int highestZoom,
-      String? parentUuid});
-}
-
-/// @nodoc
-class _$MutableLayerElementCopyWithImpl<T, $Res,
-        $Val extends MutableLayerElement<T>>
-    implements $MutableLayerElementCopyWith<T, $Res> {
-  _$MutableLayerElementCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
+  /// Create a copy of MutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @pragma('vm:prefer-inline')
+  $MutableLayerElementCopyWith<T, MutableLayerElement<T>> get copyWith =>
+      _$MutableLayerElementCopyWithImpl<T, MutableLayerElement<T>>(
+          this as MutableLayerElement<T>, _$identity);
+
   @override
-  $Res call({
-    Object? uuid = null,
-    Object? x = null,
-    Object? y = null,
-    Object? clusterData = freezed,
-    Object? visitedAtZoom = null,
-    Object? lowestZoom = null,
-    Object? highestZoom = null,
-    Object? parentUuid = freezed,
-  }) {
-    return _then(_value.copyWith(
-      uuid: null == uuid
-          ? _value.uuid
-          : uuid // ignore: cast_nullable_to_non_nullable
-              as String,
-      x: null == x
-          ? _value.x
-          : x // ignore: cast_nullable_to_non_nullable
-              as double,
-      y: null == y
-          ? _value.y
-          : y // ignore: cast_nullable_to_non_nullable
-              as double,
-      clusterData: freezed == clusterData
-          ? _value.clusterData
-          : clusterData // ignore: cast_nullable_to_non_nullable
-              as ClusterDataBase?,
-      visitedAtZoom: null == visitedAtZoom
-          ? _value.visitedAtZoom
-          : visitedAtZoom // ignore: cast_nullable_to_non_nullable
-              as int,
-      lowestZoom: null == lowestZoom
-          ? _value.lowestZoom
-          : lowestZoom // ignore: cast_nullable_to_non_nullable
-              as int,
-      highestZoom: null == highestZoom
-          ? _value.highestZoom
-          : highestZoom // ignore: cast_nullable_to_non_nullable
-              as int,
-      parentUuid: freezed == parentUuid
-          ? _value.parentUuid
-          : parentUuid // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
+  String toString() {
+    return 'MutableLayerElement<$T>(uuid: $uuid, x: $x, y: $y, clusterData: $clusterData, visitedAtZoom: $visitedAtZoom, lowestZoom: $lowestZoom, highestZoom: $highestZoom, parentUuid: $parentUuid)';
   }
 }
 
 /// @nodoc
-abstract class _$$MutableLayerClusterImplCopyWith<T, $Res>
-    implements $MutableLayerElementCopyWith<T, $Res> {
-  factory _$$MutableLayerClusterImplCopyWith(_$MutableLayerClusterImpl<T> value,
-          $Res Function(_$MutableLayerClusterImpl<T>) then) =
-      __$$MutableLayerClusterImplCopyWithImpl<T, $Res>;
-  @override
+abstract mixin class $MutableLayerElementCopyWith<T, $Res> {
+  factory $MutableLayerElementCopyWith(MutableLayerElement<T> value,
+          $Res Function(MutableLayerElement<T>) _then) =
+      _$MutableLayerElementCopyWithImpl;
   @useResult
   $Res call(
       {String uuid,
       double x,
       double y,
-      double originX,
-      double originY,
-      int childPointCount,
       ClusterDataBase? clusterData,
       int visitedAtZoom,
       int lowestZoom,
@@ -245,72 +64,58 @@ abstract class _$$MutableLayerClusterImplCopyWith<T, $Res>
 }
 
 /// @nodoc
-class __$$MutableLayerClusterImplCopyWithImpl<T, $Res>
-    extends _$MutableLayerElementCopyWithImpl<T, $Res,
-        _$MutableLayerClusterImpl<T>>
-    implements _$$MutableLayerClusterImplCopyWith<T, $Res> {
-  __$$MutableLayerClusterImplCopyWithImpl(_$MutableLayerClusterImpl<T> _value,
-      $Res Function(_$MutableLayerClusterImpl<T>) _then)
-      : super(_value, _then);
+class _$MutableLayerElementCopyWithImpl<T, $Res>
+    implements $MutableLayerElementCopyWith<T, $Res> {
+  _$MutableLayerElementCopyWithImpl(this._self, this._then);
 
+  final MutableLayerElement<T> _self;
+  final $Res Function(MutableLayerElement<T>) _then;
+
+  /// Create a copy of MutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? uuid = null,
     Object? x = null,
     Object? y = null,
-    Object? originX = null,
-    Object? originY = null,
-    Object? childPointCount = null,
     Object? clusterData = freezed,
     Object? visitedAtZoom = null,
     Object? lowestZoom = null,
     Object? highestZoom = null,
     Object? parentUuid = freezed,
   }) {
-    return _then(_$MutableLayerClusterImpl<T>(
+    return _then(_self.copyWith(
       uuid: null == uuid
-          ? _value.uuid
+          ? _self.uuid
           : uuid // ignore: cast_nullable_to_non_nullable
               as String,
       x: null == x
-          ? _value.x
+          ? _self.x
           : x // ignore: cast_nullable_to_non_nullable
               as double,
       y: null == y
-          ? _value.y
+          ? _self.y
           : y // ignore: cast_nullable_to_non_nullable
               as double,
-      originX: null == originX
-          ? _value.originX
-          : originX // ignore: cast_nullable_to_non_nullable
-              as double,
-      originY: null == originY
-          ? _value.originY
-          : originY // ignore: cast_nullable_to_non_nullable
-              as double,
-      childPointCount: null == childPointCount
-          ? _value.childPointCount
-          : childPointCount // ignore: cast_nullable_to_non_nullable
-              as int,
       clusterData: freezed == clusterData
-          ? _value.clusterData
+          ? _self.clusterData
           : clusterData // ignore: cast_nullable_to_non_nullable
               as ClusterDataBase?,
       visitedAtZoom: null == visitedAtZoom
-          ? _value.visitedAtZoom
+          ? _self.visitedAtZoom
           : visitedAtZoom // ignore: cast_nullable_to_non_nullable
               as int,
       lowestZoom: null == lowestZoom
-          ? _value.lowestZoom
+          ? _self.lowestZoom
           : lowestZoom // ignore: cast_nullable_to_non_nullable
               as int,
       highestZoom: null == highestZoom
-          ? _value.highestZoom
+          ? _self.highestZoom
           : highestZoom // ignore: cast_nullable_to_non_nullable
               as int,
       parentUuid: freezed == parentUuid
-          ? _value.parentUuid
+          ? _self.parentUuid
           : parentUuid // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
@@ -319,9 +124,9 @@ class __$$MutableLayerClusterImplCopyWithImpl<T, $Res>
 
 /// @nodoc
 
-class _$MutableLayerClusterImpl<T> extends MutableLayerCluster<T>
+class MutableLayerCluster<T> extends MutableLayerElement<T>
     with LayerCluster<T> {
-  _$MutableLayerClusterImpl(
+  MutableLayerCluster(
       {required this.uuid,
       required this.x,
       required this.y,
@@ -341,11 +146,8 @@ class _$MutableLayerClusterImpl<T> extends MutableLayerCluster<T>
   double x;
   @override
   double y;
-  @override
   double originX;
-  @override
   double originY;
-  @override
   int childPointCount;
   @override
   ClusterDataBase? clusterData;
@@ -358,219 +160,36 @@ class _$MutableLayerClusterImpl<T> extends MutableLayerCluster<T>
   @override
   String? parentUuid;
 
+  /// Create a copy of MutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $MutableLayerClusterCopyWith<T, MutableLayerCluster<T>> get copyWith =>
+      _$MutableLayerClusterCopyWithImpl<T, MutableLayerCluster<T>>(
+          this, _$identity);
+
   @override
   String toString() {
     return 'MutableLayerElement<$T>.cluster(uuid: $uuid, x: $x, y: $y, originX: $originX, originY: $originY, childPointCount: $childPointCount, clusterData: $clusterData, visitedAtZoom: $visitedAtZoom, lowestZoom: $lowestZoom, highestZoom: $highestZoom, parentUuid: $parentUuid)';
   }
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MutableLayerClusterImplCopyWith<T, _$MutableLayerClusterImpl<T>>
-      get copyWith => __$$MutableLayerClusterImplCopyWithImpl<T,
-          _$MutableLayerClusterImpl<T>>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)
-        cluster,
-    required TResult Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)
-        point,
-  }) {
-    return cluster(uuid, x, y, originX, originY, childPointCount, clusterData,
-        visitedAtZoom, lowestZoom, highestZoom, parentUuid);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        cluster,
-    TResult? Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        point,
-  }) {
-    return cluster?.call(uuid, x, y, originX, originY, childPointCount,
-        clusterData, visitedAtZoom, lowestZoom, highestZoom, parentUuid);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        cluster,
-    TResult Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        point,
-    required TResult orElse(),
-  }) {
-    if (cluster != null) {
-      return cluster(uuid, x, y, originX, originY, childPointCount, clusterData,
-          visitedAtZoom, lowestZoom, highestZoom, parentUuid);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(MutableLayerCluster<T> value) cluster,
-    required TResult Function(MutableLayerPoint<T> value) point,
-  }) {
-    return cluster(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(MutableLayerCluster<T> value)? cluster,
-    TResult? Function(MutableLayerPoint<T> value)? point,
-  }) {
-    return cluster?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(MutableLayerCluster<T> value)? cluster,
-    TResult Function(MutableLayerPoint<T> value)? point,
-    required TResult orElse(),
-  }) {
-    if (cluster != null) {
-      return cluster(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class MutableLayerCluster<T> extends MutableLayerElement<T>
-    implements LayerCluster<T> {
-  factory MutableLayerCluster(
-      {required String uuid,
-      required double x,
-      required double y,
-      required double originX,
-      required double originY,
-      required int childPointCount,
-      ClusterDataBase? clusterData,
-      required int visitedAtZoom,
-      required int lowestZoom,
-      required int highestZoom,
-      String? parentUuid}) = _$MutableLayerClusterImpl<T>;
-  MutableLayerCluster._() : super._();
-
-  @override
-  String get uuid;
-  set uuid(String value);
-  @override
-  double get x;
-  set x(double value);
-  @override
-  double get y;
-  set y(double value);
-  double get originX;
-  set originX(double value);
-  double get originY;
-  set originY(double value);
-  int get childPointCount;
-  set childPointCount(int value);
-  @override
-  ClusterDataBase? get clusterData;
-  set clusterData(ClusterDataBase? value);
-  @override
-  int get visitedAtZoom;
-  set visitedAtZoom(int value);
-  @override
-  int get lowestZoom;
-  set lowestZoom(int value);
-  @override
-  int get highestZoom;
-  set highestZoom(int value);
-  @override
-  String? get parentUuid;
-  set parentUuid(String? value);
-  @override
-  @JsonKey(ignore: true)
-  _$$MutableLayerClusterImplCopyWith<T, _$MutableLayerClusterImpl<T>>
-      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$MutableLayerPointImplCopyWith<T, $Res>
+abstract mixin class $MutableLayerClusterCopyWith<T, $Res>
     implements $MutableLayerElementCopyWith<T, $Res> {
-  factory _$$MutableLayerPointImplCopyWith(_$MutableLayerPointImpl<T> value,
-          $Res Function(_$MutableLayerPointImpl<T>) then) =
-      __$$MutableLayerPointImplCopyWithImpl<T, $Res>;
+  factory $MutableLayerClusterCopyWith(MutableLayerCluster<T> value,
+          $Res Function(MutableLayerCluster<T>) _then) =
+      _$MutableLayerClusterCopyWithImpl;
   @override
   @useResult
   $Res call(
       {String uuid,
-      T originalPoint,
-      int index,
       double x,
       double y,
+      double originX,
+      double originY,
+      int childPointCount,
       ClusterDataBase? clusterData,
       int visitedAtZoom,
       int lowestZoom,
@@ -579,67 +198,73 @@ abstract class _$$MutableLayerPointImplCopyWith<T, $Res>
 }
 
 /// @nodoc
-class __$$MutableLayerPointImplCopyWithImpl<T, $Res>
-    extends _$MutableLayerElementCopyWithImpl<T, $Res,
-        _$MutableLayerPointImpl<T>>
-    implements _$$MutableLayerPointImplCopyWith<T, $Res> {
-  __$$MutableLayerPointImplCopyWithImpl(_$MutableLayerPointImpl<T> _value,
-      $Res Function(_$MutableLayerPointImpl<T>) _then)
-      : super(_value, _then);
+class _$MutableLayerClusterCopyWithImpl<T, $Res>
+    implements $MutableLayerClusterCopyWith<T, $Res> {
+  _$MutableLayerClusterCopyWithImpl(this._self, this._then);
 
-  @pragma('vm:prefer-inline')
+  final MutableLayerCluster<T> _self;
+  final $Res Function(MutableLayerCluster<T>) _then;
+
+  /// Create a copy of MutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
   @override
+  @pragma('vm:prefer-inline')
   $Res call({
     Object? uuid = null,
-    Object? originalPoint = freezed,
-    Object? index = null,
     Object? x = null,
     Object? y = null,
+    Object? originX = null,
+    Object? originY = null,
+    Object? childPointCount = null,
     Object? clusterData = freezed,
     Object? visitedAtZoom = null,
     Object? lowestZoom = null,
     Object? highestZoom = null,
     Object? parentUuid = freezed,
   }) {
-    return _then(_$MutableLayerPointImpl<T>(
+    return _then(MutableLayerCluster<T>(
       uuid: null == uuid
-          ? _value.uuid
+          ? _self.uuid
           : uuid // ignore: cast_nullable_to_non_nullable
               as String,
-      originalPoint: freezed == originalPoint
-          ? _value.originalPoint
-          : originalPoint // ignore: cast_nullable_to_non_nullable
-              as T,
-      index: null == index
-          ? _value.index
-          : index // ignore: cast_nullable_to_non_nullable
-              as int,
       x: null == x
-          ? _value.x
+          ? _self.x
           : x // ignore: cast_nullable_to_non_nullable
               as double,
       y: null == y
-          ? _value.y
+          ? _self.y
           : y // ignore: cast_nullable_to_non_nullable
               as double,
+      originX: null == originX
+          ? _self.originX
+          : originX // ignore: cast_nullable_to_non_nullable
+              as double,
+      originY: null == originY
+          ? _self.originY
+          : originY // ignore: cast_nullable_to_non_nullable
+              as double,
+      childPointCount: null == childPointCount
+          ? _self.childPointCount
+          : childPointCount // ignore: cast_nullable_to_non_nullable
+              as int,
       clusterData: freezed == clusterData
-          ? _value.clusterData
+          ? _self.clusterData
           : clusterData // ignore: cast_nullable_to_non_nullable
               as ClusterDataBase?,
       visitedAtZoom: null == visitedAtZoom
-          ? _value.visitedAtZoom
+          ? _self.visitedAtZoom
           : visitedAtZoom // ignore: cast_nullable_to_non_nullable
               as int,
       lowestZoom: null == lowestZoom
-          ? _value.lowestZoom
+          ? _self.lowestZoom
           : lowestZoom // ignore: cast_nullable_to_non_nullable
               as int,
       highestZoom: null == highestZoom
-          ? _value.highestZoom
+          ? _self.highestZoom
           : highestZoom // ignore: cast_nullable_to_non_nullable
               as int,
       parentUuid: freezed == parentUuid
-          ? _value.parentUuid
+          ? _self.parentUuid
           : parentUuid // ignore: cast_nullable_to_non_nullable
               as String?,
     ));
@@ -648,9 +273,8 @@ class __$$MutableLayerPointImplCopyWithImpl<T, $Res>
 
 /// @nodoc
 
-class _$MutableLayerPointImpl<T> extends MutableLayerPoint<T>
-    with LayerPoint<T> {
-  _$MutableLayerPointImpl(
+class MutableLayerPoint<T> extends MutableLayerElement<T> with LayerPoint<T> {
+  MutableLayerPoint(
       {required this.uuid,
       required this.originalPoint,
       required this.index,
@@ -665,9 +289,7 @@ class _$MutableLayerPointImpl<T> extends MutableLayerPoint<T>
 
   @override
   String uuid;
-  @override
   T originalPoint;
-  @override
   final int index;
 // Zero-based index of point addition.
   @override
@@ -685,198 +307,109 @@ class _$MutableLayerPointImpl<T> extends MutableLayerPoint<T>
   @override
   String? parentUuid;
 
+  /// Create a copy of MutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $MutableLayerPointCopyWith<T, MutableLayerPoint<T>> get copyWith =>
+      _$MutableLayerPointCopyWithImpl<T, MutableLayerPoint<T>>(
+          this, _$identity);
+
   @override
   String toString() {
     return 'MutableLayerElement<$T>.point(uuid: $uuid, originalPoint: $originalPoint, index: $index, x: $x, y: $y, clusterData: $clusterData, visitedAtZoom: $visitedAtZoom, lowestZoom: $lowestZoom, highestZoom: $highestZoom, parentUuid: $parentUuid)';
   }
+}
 
-  @JsonKey(ignore: true)
+/// @nodoc
+abstract mixin class $MutableLayerPointCopyWith<T, $Res>
+    implements $MutableLayerElementCopyWith<T, $Res> {
+  factory $MutableLayerPointCopyWith(MutableLayerPoint<T> value,
+          $Res Function(MutableLayerPoint<T>) _then) =
+      _$MutableLayerPointCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String uuid,
+      T originalPoint,
+      int index,
+      double x,
+      double y,
+      ClusterDataBase? clusterData,
+      int visitedAtZoom,
+      int lowestZoom,
+      int highestZoom,
+      String? parentUuid});
+}
+
+/// @nodoc
+class _$MutableLayerPointCopyWithImpl<T, $Res>
+    implements $MutableLayerPointCopyWith<T, $Res> {
+  _$MutableLayerPointCopyWithImpl(this._self, this._then);
+
+  final MutableLayerPoint<T> _self;
+  final $Res Function(MutableLayerPoint<T>) _then;
+
+  /// Create a copy of MutableLayerElement
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$MutableLayerPointImplCopyWith<T, _$MutableLayerPointImpl<T>>
-      get copyWith =>
-          __$$MutableLayerPointImplCopyWithImpl<T, _$MutableLayerPointImpl<T>>(
-              this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)
-        cluster,
-    required TResult Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)
-        point,
+  $Res call({
+    Object? uuid = null,
+    Object? originalPoint = freezed,
+    Object? index = null,
+    Object? x = null,
+    Object? y = null,
+    Object? clusterData = freezed,
+    Object? visitedAtZoom = null,
+    Object? lowestZoom = null,
+    Object? highestZoom = null,
+    Object? parentUuid = freezed,
   }) {
-    return point(uuid, originalPoint, index, x, y, clusterData, visitedAtZoom,
-        lowestZoom, highestZoom, parentUuid);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        cluster,
-    TResult? Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        point,
-  }) {
-    return point?.call(uuid, originalPoint, index, x, y, clusterData,
-        visitedAtZoom, lowestZoom, highestZoom, parentUuid);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            String uuid,
-            double x,
-            double y,
-            double originX,
-            double originY,
-            int childPointCount,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        cluster,
-    TResult Function(
-            String uuid,
-            T originalPoint,
-            int index,
-            double x,
-            double y,
-            ClusterDataBase? clusterData,
-            int visitedAtZoom,
-            int lowestZoom,
-            int highestZoom,
-            String? parentUuid)?
-        point,
-    required TResult orElse(),
-  }) {
-    if (point != null) {
-      return point(uuid, originalPoint, index, x, y, clusterData, visitedAtZoom,
-          lowestZoom, highestZoom, parentUuid);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(MutableLayerCluster<T> value) cluster,
-    required TResult Function(MutableLayerPoint<T> value) point,
-  }) {
-    return point(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(MutableLayerCluster<T> value)? cluster,
-    TResult? Function(MutableLayerPoint<T> value)? point,
-  }) {
-    return point?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(MutableLayerCluster<T> value)? cluster,
-    TResult Function(MutableLayerPoint<T> value)? point,
-    required TResult orElse(),
-  }) {
-    if (point != null) {
-      return point(this);
-    }
-    return orElse();
+    return _then(MutableLayerPoint<T>(
+      uuid: null == uuid
+          ? _self.uuid
+          : uuid // ignore: cast_nullable_to_non_nullable
+              as String,
+      originalPoint: freezed == originalPoint
+          ? _self.originalPoint
+          : originalPoint // ignore: cast_nullable_to_non_nullable
+              as T,
+      index: null == index
+          ? _self.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+      x: null == x
+          ? _self.x
+          : x // ignore: cast_nullable_to_non_nullable
+              as double,
+      y: null == y
+          ? _self.y
+          : y // ignore: cast_nullable_to_non_nullable
+              as double,
+      clusterData: freezed == clusterData
+          ? _self.clusterData
+          : clusterData // ignore: cast_nullable_to_non_nullable
+              as ClusterDataBase?,
+      visitedAtZoom: null == visitedAtZoom
+          ? _self.visitedAtZoom
+          : visitedAtZoom // ignore: cast_nullable_to_non_nullable
+              as int,
+      lowestZoom: null == lowestZoom
+          ? _self.lowestZoom
+          : lowestZoom // ignore: cast_nullable_to_non_nullable
+              as int,
+      highestZoom: null == highestZoom
+          ? _self.highestZoom
+          : highestZoom // ignore: cast_nullable_to_non_nullable
+              as int,
+      parentUuid: freezed == parentUuid
+          ? _self.parentUuid
+          : parentUuid // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
   }
 }
 
-abstract class MutableLayerPoint<T> extends MutableLayerElement<T>
-    implements LayerPoint<T> {
-  factory MutableLayerPoint(
-      {required String uuid,
-      required T originalPoint,
-      required final int index,
-      required double x,
-      required double y,
-      ClusterDataBase? clusterData,
-      required int visitedAtZoom,
-      required int lowestZoom,
-      required int highestZoom,
-      String? parentUuid}) = _$MutableLayerPointImpl<T>;
-  MutableLayerPoint._() : super._();
-
-  @override
-  String get uuid;
-  set uuid(String value);
-  T get originalPoint;
-  set originalPoint(T value);
-  int get index;
-  @override // Zero-based index of point addition.
-  double get x; // Zero-based index of point addition.
-  set x(double value);
-  @override
-  double get y;
-  set y(double value);
-  @override
-  ClusterDataBase? get clusterData;
-  set clusterData(ClusterDataBase? value);
-  @override
-  int get visitedAtZoom;
-  set visitedAtZoom(int value);
-  @override
-  int get lowestZoom;
-  set lowestZoom(int value);
-  @override
-  int get highestZoom;
-  set highestZoom(int value);
-  @override
-  String? get parentUuid;
-  set parentUuid(String? value);
-  @override
-  @JsonKey(ignore: true)
-  _$$MutableLayerPointImplCopyWith<T, _$MutableLayerPointImpl<T>>
-      get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/supercluster.dart
+++ b/lib/supercluster.dart
@@ -33,12 +33,12 @@ abstract class Supercluster<T> {
     int? radius,
     int? extent,
     this.extractClusterData,
-  })  : assert(minPoints == null || minPoints > 1),
-        minZoom = minZoom ?? 0,
-        maxZoom = maxZoom ?? 16,
-        minPoints = minPoints ?? 2,
-        radius = radius ?? 40,
-        extent = extent ?? 512;
+  }) : assert(minPoints == null || minPoints > 1),
+       minZoom = minZoom ?? 0,
+       maxZoom = maxZoom ?? 16,
+       minPoints = minPoints ?? 2,
+       radius = radius ?? 40,
+       extent = extent ?? 512;
 
   /// Remove any existing points and replace them with [points]. This will
   /// recreate the index completely and may take some time. If you want to

--- a/packages/test_app/lib/lat_lon_grid.dart
+++ b/packages/test_app/lib/lat_lon_grid.dart
@@ -17,10 +17,10 @@ class LatLonGrid extends StatelessWidget {
             options: LatLonGridLayerOptions(
               lineWidth: 0.5,
               // apply alpha for grid lines
-              lineColor: Colors.black.withOpacity(0.1),
+              lineColor: Colors.black.withAlpha((0.1 * 255).toInt()),
               labelStyle: TextStyle(
                 color: Colors.white,
-                backgroundColor: Colors.black.withOpacity(0.1),
+                backgroundColor: Colors.black.withAlpha((0.1 * 255).toInt()),
                 fontSize: 12.0,
               ),
               showCardinalDirections: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  freezed_annotation: ^2.4.2
+  freezed_annotation: ^3.0.0
   kdbush: ^0.1.0
   rbush: ^1.1.1
   uuid: ^4.4.0
@@ -15,8 +15,8 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.11
   compute: ^1.0.2
-  freezed: ^2.5.4
-  lints: ^4.0.0
+  freezed: ^3.0.2
+  lints: ^5.1.1
   test: ^1.25.8
   quiver: ^3.2.1
 


### PR DESCRIPTION
Bump dependencies, switched to pattern matching (freezed ^3.0.0 no longer uses .map), added context guard, and upgraded from deprecated APIs.